### PR TITLE
Fix issue with end tag style

### DIFF
--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -42,16 +42,19 @@ export default class Node extends React.Component {
         <span style={tagStyle}> /&gt;</span>
       </div>;
     }
+    
+    // Keep a copy so that further mutations to containerStyle don't impact us:
+    const containerStyleCopy = Object.assign({}, containerStyle);
 
     // tag with children
     return <div>
-      <div style={containerStyle}>
+      <div style={containerStyleCopy}>
         <span style={tagStyle}>&lt;{name}</span>
           <Props node={node} />
         <span style={tagStyle}>&gt;</span>
       </div>
       {React.Children.map(children, childElement => <Node node={childElement} depth={depth + 1}/>)}
-      <div style={containerStyle}>
+      <div style={containerStyleCopy}>
         <span style={tagStyle}>&lt;/{name}&gt;</span>
       </div>
     </div>


### PR DESCRIPTION
In the "_view source_" section, I noticed that the end tag was always indented one level too much, and was being aligned with the children. This is because the `containerStyle` was being mutated by the child `<Node>` components while rendering. This PR copies the `containerStyle` into a new object when we're about to render `<Node>` components to prevent the child components from changing the styles from under our feet.
