### PR TITLE
Display more info on default props

### DIFF
--- a/src/components/PropTable.js
+++ b/src/components/PropTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropVal from './PropVal'
 
 const PropTypesMap = new Map();
 for (let typeName in React.PropTypes) {
@@ -27,8 +28,7 @@ export default class PropTable extends React.Component {
         const typeInfo = type.propTypes[property];
         const propType = PropTypesMap.get(typeInfo) || 'other';
         const required = typeInfo.isRequired === undefined ? 'yes' : 'no';
-        const defaultValue = '-';
-        props[property] = {property, propType, required, defaultValue};
+        props[property] = {property, propType, required};
       }
     }
 
@@ -72,7 +72,7 @@ export default class PropTable extends React.Component {
               <td>{row.property}</td>
               <td>{row.propType}</td>
               <td>{row.required}</td>
-              <td>{row.defaultValue.toString()}</td>
+              <td>{row.defaultValue === undefined  ? '-' : <PropVal val={row.defaultValue} />}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
Default props on the prop table are displayed using the same 'PropVal' component used in source code section.

They will be shown like this.

<img width="619" alt="screen shot 2016-06-23 at 11 58 18 am" src="https://cloud.githubusercontent.com/assets/3872221/16293759/095cc2fe-393a-11e6-9cfd-6a3c6b622614.png">
