### PR TITLE
Improved rendering of props

### DIFF
--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -38,26 +38,30 @@ export default class Node extends React.Component {
     if (!children) {
       return <div style={containerStyle}>
         <span style={tagStyle}>&lt;{name}</span>
-          <Props node={node} />
-        <span style={tagStyle}> /&gt;</span>
+          <Props node={node} singleLine />
+        <span style={tagStyle}>/&gt;</span>
       </div>;
     }
-    
+
     // Keep a copy so that further mutations to containerStyle don't impact us:
     const containerStyleCopy = Object.assign({}, containerStyle);
 
     // tag with children
-    return <div>
-      <div style={containerStyleCopy}>
-        <span style={tagStyle}>&lt;{name}</span>
-          <Props node={node} />
-        <span style={tagStyle}>&gt;</span>
+    return (
+      <div>
+        <div style={containerStyleCopy}>
+          <span style={tagStyle}>&lt;{name}</span>
+            <Props node={node} />
+          <span style={tagStyle}>&gt;</span>
+        </div>
+        {React.Children.map(children, childElement => (
+          <Node node={childElement} depth={depth + 1} />
+        ))}
+        <div style={containerStyleCopy}>
+          <span style={tagStyle}>&lt;/{name}&gt;</span>
+        </div>
       </div>
-      {React.Children.map(children, childElement => <Node node={childElement} depth={depth + 1}/>)}
-      <div style={containerStyleCopy}>
-        <span style={tagStyle}>&lt;/{name}&gt;</span>
-      </div>
-    </div>
+    );
   }
 }
 

--- a/src/components/PropVal.js
+++ b/src/components/PropVal.js
@@ -76,35 +76,38 @@ function previewObject(val) {
 }
 
 function previewProp(val) {
+  let braceWrap = true;
+  let content = null;
   if (typeof val === 'number') {
-    return <span style={valueStyles.number}>{val}</span>;
-  }
-  if (typeof val === 'string') {
+    content = <span style={valueStyles.number}>{val}</span>;
+  } else if (typeof val === 'string') {
     if (val.length > 50) {
       val = val.slice(0, 50) + '…';
     }
-    return <span style={valueStyles.string}>"{val}"</span>;
-  }
-  if (typeof val === 'boolean') {
-    return <span style={valueStyles.bool}>{`${val}`}</span>;
-  }
-  if (Array.isArray(val)) {
-    return previewArray(val);
-  }
-  if (typeof val === 'function') {
-    return <span style={valueStyles.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
-  }
-  if (!val) {
-    return <span style={valueStyles.empty}>{`${val}`}</span>;
-  }
-  if (typeof val !== 'object') {
-    return <span>…</span>;
-  }
-  if (React.isValidElement(val)) {
-    return <span style={valueStyles.object}>{`<${val.type.displayName || val.type.name || val.type } />`}</span>
+    content = <span style={valueStyles.string}>"{val}"</span>;
+    braceWrap = false;
+  } else if (typeof val === 'boolean') {
+    content = <span style={valueStyles.bool}>{`${val}`}</span>;
+  } else if (Array.isArray(val)) {
+    content = previewArray(val);
+  } else if (typeof val === 'function') {
+    content = <span style={valueStyles.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
+  } else if (!val) {
+    content = <span style={valueStyles.empty}>{`${val}`}</span>;
+  } else if (typeof val !== 'object') {
+    content = <span>…</span>;
+  } else if (React.isValidElement(val)) {
+    content = (
+      <span style={valueStyles.object}>
+        {`<${val.type.displayName || val.type.name || val.type} />`}
+      </span>
+    );
+  } else {
+    content = previewObject(val);
   }
 
-  return previewObject(val);
+  if (!braceWrap) return content;
+  return <span>&#123;{content}&#125;</span>;
 }
 
 export default class PropVal extends React.Component {

--- a/src/components/Props.js
+++ b/src/components/Props.js
@@ -38,7 +38,7 @@ export default class Props extends React.Component {
           ) : ' '}
           <span style={propNameStyle}>{name}</span>
           {/* Use implicit true: */}
-          {!props[name] || typeof props[name] !== 'boolean' && (
+          {(!props[name] || typeof props[name] !== 'boolean') && (
             <span>
               =
               <span style={propValueStyle}><PropVal val={props[name]} /></span>

--- a/src/components/Props.js
+++ b/src/components/Props.js
@@ -3,13 +3,10 @@ import PropVal from './PropVal';
 
 const stylesheet = {
   propStyle: {
-    paddingLeft: 8,
   },
   propNameStyle: {
-
   },
   propValueStyle: {
-
   }
 }
 
@@ -18,7 +15,7 @@ export default class Props extends React.Component {
     const props = this.props.node.props;
     const defaultProps = this.props.node.type.defaultProps;
     if (!props || typeof props !== 'object') {
-      return <span/>;
+      return <span />;
     }
 
     const {propStyle, propValueStyle, propNameStyle} = stylesheet;
@@ -27,17 +24,34 @@ export default class Props extends React.Component {
       return name[0] !== '_' && name !== 'children' && (!defaultProps || props[name] != defaultProps[name]);
     });
 
+    const breakIntoNewLines = names.length > 3;
+    const endingSpace = this.props.singleLine ? ' ' : '';
+
     const items = [];
-    names.slice(0, 3).forEach(name => {
+    names.forEach((name, i) => {
       items.push(
-        <span key={name} style={propStyle}>
+        <span key={name}>
+          {breakIntoNewLines ? (
+            <span>
+              <br />&nbsp;&nbsp;
+            </span>
+          ) : ' '}
           <span style={propNameStyle}>{name}</span>
-          =
-          <span style={propValueStyle}><PropVal val={props[name]} /></span>
+          {/* Use implicit true: */}
+          {!props[name] || typeof props[name] !== 'boolean' && (
+            <span>
+              =
+              <span style={propValueStyle}><PropVal val={props[name]} /></span>
+            </span>
+          )}
+
+          {i === (names.length - 1) && (
+            breakIntoNewLines ? <br /> : endingSpace
+          )}
         </span>
       );
     });
 
-    return <span>{items}</span>
+    return <span>{items}</span>;
   }
 }


### PR DESCRIPTION
This improves how props are rendered, with the intent of solving #22.
- Wraps all required values with `{}` in the jsx. Strings remain un-wrapped.
- Boolean true values will now have the `={true}` omitted to prefer the JSX shorthand.
- Doesn't limit the number of props that can be displayed.
- If there are more than 3 props, they are split across multiple lines.
- Space between props is actual whitespace, so copying and pasting should be possible!
