### PR TITLE
Remove the max-width limitation in documentation page.

### DIFF
--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -55,7 +55,7 @@ const stylesheet = {
   infoBody: {
     ...baseFonts,
     fontWeight: 300,
-    maxWidth: '48rem',
+    maxWidth: 100%,
     lineHeight: 1.45,
     fontSize: 15,
   },


### PR DESCRIPTION
I don't understand why should it be limited to 48rem, and it sounds like a random value.

I'm not really sure If It's really necessary.
