### PR TITLE
Handle css resets

### DIFF
--- a/src/components/PropTable.js
+++ b/src/components/PropTable.js
@@ -10,6 +10,14 @@ for (let typeName in React.PropTypes) {
   PropTypesMap.set(type, typeName);
 }
 
+const stylesheet = {
+  propTable: {
+    marginLeft: -10,
+    borderSpacing: '10px 5px',
+    borderCollapse: 'separate',
+  }
+};
+
 export default class PropTable extends React.Component {
   render () {
     const type = this.props.type;
@@ -57,7 +65,7 @@ export default class PropTable extends React.Component {
     });
 
     return (
-      <table>
+      <table style={stylesheet.propTable}>
         <thead>
           <tr>
             <th>property</th>

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -86,7 +86,10 @@ const stylesheet = {
       fontSize: 25,
       borderBottom: '1px solid #EEE',
     }
-  }
+  },
+  propTableHead: {
+    margin: '20px 0 0 0'
+  },
 }
 
 export default class Story extends React.Component {
@@ -263,7 +266,7 @@ export default class Story extends React.Component {
     const propTables = array.map(function (type, idx) {
       return (
         <div key={idx}>
-          <h2>"{type.displayName || type.name}" Component</h2>
+          <h2 style={stylesheet.propTableHead}>"{type.displayName || type.name}" Component</h2>
           <PropTable type={type} />
         </div>
       );


### PR DESCRIPTION
Add paddings/margins removed by css resets [example issue](https://white-rabbit-japan.github.io/Semantic-UI-React-Storybook/?selectedKind=Progress&selectedStory=Standard&full=0&down=0&left=1).
CC: @Maxhodges 
