### PR TITLE
Moved the rendered component into its own div

### DIFF
--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -55,7 +55,7 @@ const stylesheet = {
   infoBody: {
     ...baseFonts,
     fontWeight: 300,
-    maxWidth: 100%,
+    maxWidth: '100%',
     lineHeight: 1.45,
     fontSize: 15,
   },
@@ -119,7 +119,13 @@ export default class Story extends React.Component {
         <div style={stylesheet.infoPage}>
           <div style={stylesheet.infoBody} >
             { this._getInfoHeader() }
+          </div>
+        </div>
+        <div>
             { this._renderStory() }
+        </div>
+        <div style={stylesheet.infoPage}>
+          <div style={stylesheet.infoBody} >
             { this._getInfoContent() }
             { this._getSourceCode() }
             { this._getPropTables() }


### PR DESCRIPTION
May not be the cleanest implementation, but seems to keep the styling right and it no longer affects the component. Addresses #33 

Also surrounded maxWidth:100% with quotes to remove build error caused by previous patch.
