### PR TITLE
Delete infobody maxWidth

### DIFF
--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -55,7 +55,6 @@ const stylesheet = {
   infoBody: {
     ...baseFonts,
     fontWeight: 300,
-    maxWidth: 100%,
     lineHeight: 1.45,
     fontSize: 15,
   },


### PR DESCRIPTION
https://github.com/kadirahq/react-storybook-addon-info/pull/31#issuecomment-229544024

Delete maxWidth as suggested by @mnmtanish.
