### PR TITLE
Fix story content not showing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,14 @@ export default {
       ...defaultOptions,
       ..._options
     };
-    
+
     this.add(storyName, (context) => {
       let info = _info;
       let storyFn = _storyFn;
-      
+
       if (typeof storyFn !== 'function') {
         if (typeof info === 'function') {
+          options = storyFn;
           storyFn = info;
           info = '';
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -9,27 +9,27 @@ const defaultOptions = {
 };
 
 export default {
-  addWithInfo(storyName, info, storyFn, _options) {
+  addWithInfo(storyName, _info, _storyFn, _options) {
     const options = {
       ...defaultOptions,
       ..._options
     };
     
     this.add(storyName, (context) => {
-      let _info = info;
-      let _storyFn = storyFn;
+      let info = _info;
+      let storyFn = _storyFn;
       
       if (typeof storyFn !== 'function') {
         if (typeof info === 'function') {
-          _storyFn = info;
-          _info = '';
+          storyFn = info;
+          info = '';
         } else {
           throw new Error('No story defining function has been specified');
         }
       }
 
       const props = {
-        _info,
+        info,
         context,
         showInline: Boolean(options.inline),
         showHeader: Boolean(options.header),
@@ -39,7 +39,7 @@ export default {
 
       return (
         <Story {...props}>
-          {_storyFn(context)}
+          {storyFn(context)}
         </Story>
       );
     });


### PR DESCRIPTION
Fix property naming. `_info` is not a correct prop for StoryComponent. Broken by: https://github.com/kadirahq/react-storybook-addon-info/commit/8bb7115fcf76c66e2496bb6481230abb24a079ab
