### PR TITLE
Fix wrong detection of propType when isRequired is set

### DIFF
--- a/src/components/PropTable.js
+++ b/src/components/PropTable.js
@@ -8,6 +8,7 @@ for (let typeName in React.PropTypes) {
   }
   const type = React.PropTypes[typeName];
   PropTypesMap.set(type, typeName);
+  PropTypesMap.set(type.isRequired, typeName);
 }
 
 const stylesheet = {

--- a/src/components/PropTable.js
+++ b/src/components/PropTable.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropVal from './PropVal'
+import PropVal from './PropVal';
 
 const PropTypesMap = new Map();
-for (let typeName in React.PropTypes) {
+for (const typeName in React.PropTypes) {
   if (!React.PropTypes.hasOwnProperty(typeName)) {
-    continue
+    continue;
   }
   const type = React.PropTypes[typeName];
   PropTypesMap.set(type, typeName);
@@ -16,11 +16,11 @@ const stylesheet = {
     marginLeft: -10,
     borderSpacing: '10px 5px',
     borderCollapse: 'separate',
-  }
+  },
 };
 
 export default class PropTable extends React.Component {
-  render () {
+  render() {
     const type = this.props.type;
 
     if (!type) {
@@ -30,28 +30,28 @@ export default class PropTable extends React.Component {
     const props = {};
 
     if (type.propTypes) {
-      for (let property in type.propTypes) {
+      for (const property in type.propTypes) {
         if (!type.propTypes.hasOwnProperty(property)) {
-          continue
+          continue;
         }
         const typeInfo = type.propTypes[property];
         const propType = PropTypesMap.get(typeInfo) || 'other';
         const required = typeInfo.isRequired === undefined ? 'yes' : 'no';
-        props[property] = {property, propType, required};
+        props[property] = { property, propType, required };
       }
     }
 
     if (type.defaultProps) {
-      for (let property in type.defaultProps) {
+      for (const property in type.defaultProps) {
         if (!type.defaultProps.hasOwnProperty(property)) {
-          continue
+          continue;
         }
         const value = type.defaultProps[property];
         if (value === undefined) {
           continue;
         }
         if (!props[property]) {
-          props[property] = {property};
+          props[property] = { property };
         }
         props[property].defaultValue = value;
       }
@@ -81,7 +81,7 @@ export default class PropTable extends React.Component {
               <td>{row.property}</td>
               <td>{row.propType}</td>
               <td>{row.required}</td>
-              <td>{row.defaultValue === undefined  ? '-' : <PropVal val={row.defaultValue} />}</td>
+              <td>{row.defaultValue === undefined ? '-' : <PropVal val={row.defaultValue} />}</td>
             </tr>
           ))}
         </tbody>
@@ -92,5 +92,5 @@ export default class PropTable extends React.Component {
 
 PropTable.displayName = 'PropTable';
 PropTable.propTypes = {
-  type: React.PropTypes.func
+  type: React.PropTypes.func,
 };


### PR DESCRIPTION
From the [example page](https://kadirahq.github.io/react-storybook-addon-info) the propType of label is detected as `other`.
![screen shot 2559-08-10 at 6 29 22 pm](https://cloud.githubusercontent.com/assets/7040242/17552601/09eed6d2-5f2b-11e6-840d-ce847c641da2.png)
But actually it is `string`, as you can see in the screenshot from [example/Button.js](https://github.com/kadirahq/react-storybook-addon-info/blob/master/example/Button.js) below.
![screen shot 2559-08-10 at 6 29 49 pm](https://cloud.githubusercontent.com/assets/7040242/17552625/35ea1a08-5f2b-11e6-8f99-e0de7f07e51c.png)

As I investigated further, I realise that whenever `isRequired` is set in the prop, the proptype will be detected as `other`.

It's because in [src/components/PropTable.js](https://github.com/kadirahq/react-storybook-addon-info/blob/master/src/components/PropTable.js), `PropTypesMap` only store result from properties of `React.PropTypes`. And when the prop is set as `isRequired`, there's no match in `PropTypesMap`.

So I need to store `type.isRequired` in `PropTypesMap` as well so that `isRequired` prop can be detected.
