### PR TITLE
Handle propTables=false properly

### DIFF
--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -224,7 +224,7 @@ export default class Story extends React.Component {
   _getPropTables() {
     const types = new Map();
 
-    if (this.props.propTables === false) {
+    if (this.props.propTables === null) {
       return null;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,13 @@ export default {
       ..._options
     };
 
+    // props.propTables can only be either an array of components or null
+    // propTables option is allowed to be set to 'false' (a boolean)
+    // if the option is false, replace it with null to avoid react warnings
+    if (!options.propTables) {
+      options.propTables = null;
+    }
+
     this.add(storyName, (context) => {
       const props = {
         info,


### PR DESCRIPTION
The propTables prop is an array type but the option
may be set to false. Change it to null to avoid warnings
