### PR TITLE
Fix bug where proptables are disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const defaultOptions = {
   inline: false,
   header: true,
   source: true,
+  propTables: [],
 };
 
 const defaultMtrcConf = {
@@ -44,7 +45,7 @@ export default {
     // props.propTables can only be either an array of components or null
     // propTables option is allowed to be set to 'false' (a boolean)
     // if the option is false, replace it with null to avoid react warnings
-    if (options.propTables === false) {
+    if (!options.propTables) {
       options.propTables = null;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const defaultMtrcConf = {
 
 export default {
   addWithInfo(storyName, info, storyFn, _options) {
-    
+
     if (typeof storyFn !== 'function') {
       if (typeof info === 'function') {
         _options = storyFn;
@@ -40,19 +40,19 @@ export default {
       ...defaultOptions,
       ..._options
     };
-  
+
     // props.propTables can only be either an array of components or null
     // propTables option is allowed to be set to 'false' (a boolean)
     // if the option is false, replace it with null to avoid react warnings
-    if (!options.propTables) {
+    if (options.propTables === false) {
       options.propTables = null;
     }
-  
+
     const mtrcConf = { ...defaultMtrcConf };
     if (_options && _options.mtrcConf) {
       Object.assign(mtrcConf, _options.mtrcConf);
     }
-	
+
     this.add(storyName, (context) => {
       const props = {
         info,


### PR DESCRIPTION
Pull request number 53 sets the propTables to null
when it's undefined. But propTables should be true by default.
