### PR TITLE
Install addon as devDependency in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A React Storybook addon to show additional information for your stories.
 Install the following npm module:
 
 ```sh
-npm i --save @kadira/react-storybook-addon-info
+npm i -D @kadira/react-storybook-addon-info
 ```
 
 Then set the addon in the place you configure storybook like this:


### PR DESCRIPTION
Hi,

`react-storybook` and all other addons document their install proccess as a devDependency.
I guess it's the right target.
