### PR TITLE
Fixed `markdown-to-react-components` version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "markdown-to-react-components": "kadirahq/markdown-to-react-components",
+    "markdown-to-react-components": "^0.2.1",
     "react-addons-create-fragment": "^15.3.2"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
I found that the version of `markdown-to-react-components` wasn't specified properly in `package.json`, so I updated it to the latest version.
