### PR TITLE
Pass the langauge class in code for Prism highlights

### DIFF
--- a/src/components/markdown/code.js
+++ b/src/components/markdown/code.js
@@ -1,6 +1,21 @@
 import React from 'react';
 
 export class Code extends React.Component {
+
+  componentDidMount() {
+    this.highlight()
+  }
+
+  componentDidUpdate() {
+    this.highlight()
+  }
+
+  highlight() {
+    if (typeof Prism !== 'undefined') {
+      Prism.highlightAll()
+    }
+  }
+
   render() {
     const codeStyle = {
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',

--- a/src/components/markdown/code.js
+++ b/src/components/markdown/code.js
@@ -15,9 +15,11 @@ export class Code extends React.Component {
       overflowX: 'scroll',
     };
 
+    const className = this.props.language ? `language-${this.props.language}` : '';
+
     return (
-      <pre style={preStyle}>
-        <code style={codeStyle}>
+      <pre style={preStyle} className={className}>
+        <code style={codeStyle} className={className}>
           { this.props.code }
         </code>
       </pre>


### PR DESCRIPTION
In order for the MTRC to support syntax highlighting in syntax fences (````javascript`) it needs to pass the `class="language-javascript"` down to the pre/code elements
