### PR TITLE
Upgrade markdown-to-react-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "markdown-to-react-components": "^0.2.1",
+    "markdown-to-react-components": "^0.2.2",
     "react-addons-create-fragment": "^15.3.2"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
I noticed that I wasn't able to customize codespans, and that this was
resolved in a newer version of markdown-to-react-components.