### PR TITLE
Allow mtrcConf to be set through setDefaults

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73,8 +73,8 @@ exports.default = {
     }
 
     var mtrcConf = (0, _extends3.default)({}, defaultMtrcConf);
-    if (_options && _options.mtrcConf) {
-      (0, _assign2.default)(mtrcConf, _options.mtrcConf);
+    if (options && options.mtrcConf) {
+      (0, _assign2.default)(mtrcConf, options.mtrcConf);
     }
 
     this.add(storyName, function (context) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "markdown-to-react-components": "^0.2.2",
+    "markdown-to-react-components": "^0.2.1",
     "react-addons-create-fragment": "^15.3.2"
   },
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "markdown-to-react-components": "^0.2.1",
+    "markdown-to-react-components": "^0.2.2",
     "react-addons-create-fragment": "^15.3.2"
   },
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ export default {
     }
 
     const mtrcConf = { ...defaultMtrcConf };
-    if (_options && _options.mtrcConf) {
-      Object.assign(mtrcConf, _options.mtrcConf);
+    if (options && options.mtrcConf) {
+      Object.assign(mtrcConf, options.mtrcConf);
     }
 
     this.add(storyName, (context) => {


### PR DESCRIPTION
In my project I would like to add some default styling for markdown components, but for some reason `_options` was used instead of `options`, so I decided to create a PR.