### PR TITLE
Add propTablesExclude option

### DIFF
--- a/dist/components/Story.js
+++ b/dist/components/Story.js
@@ -325,6 +325,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_getPropTables',
     value: function _getPropTables() {
+      var _this3 = this;
+
       var types = new _map2.default();
 
       if (this.props.propTables === null) {
@@ -342,7 +344,7 @@ var Story = function (_React$Component) {
       }
 
       // depth-first traverse and collect types
-      function extract(children) {
+      var extract = function extract(children) {
         if (!children) {
           return;
         }
@@ -353,13 +355,14 @@ var Story = function (_React$Component) {
         if (children.props && children.props.children) {
           extract(children.props.children);
         }
-        if (typeof children === 'string' || typeof children.type === 'string') {
+        if (typeof children === 'string' || typeof children.type === 'string' || Array.isArray(_this3.props.propTablesExclude) && // also ignore excluded types
+          ~_this3.props.propTablesExclude.indexOf(children.type)) {
           return;
         }
         if (children.type && !types.has(children.type)) {
           types.set(children.type, true);
         }
-      }
+      };
 
       // extract components from children
       extract(this.props.children);
@@ -422,6 +425,7 @@ Story.propTypes = {
   context: _react2.default.PropTypes.object,
   info: _react2.default.PropTypes.string,
   propTables: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.func),
+  propTablesExclude: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.func),
   showInline: _react2.default.PropTypes.bool,
   showHeader: _react2.default.PropTypes.bool,
   showSource: _react2.default.PropTypes.bool,

--- a/dist/index.js
+++ b/dist/index.js
@@ -85,6 +85,7 @@ exports.default = {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        propTablesExclude: options.propTablesExclude,
         mtrcConf: mtrcConf
       };
 

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -225,7 +225,7 @@ export default class Story extends React.Component {
     }
 
     // depth-first traverse and collect types
-    function extract(children) {
+    const extract = children => {
       if (!children) {
         return;
       }
@@ -236,13 +236,15 @@ export default class Story extends React.Component {
       if (children.props && children.props.children) {
         extract(children.props.children);
       }
-      if (typeof children === 'string' || typeof children.type === 'string') {
+      if (typeof children === 'string' || typeof children.type === 'string' ||
+        Array.isArray(this.props.propTablesExclude) && // also ignore excluded types
+        ~this.props.propTablesExclude.indexOf(children.type)) {
         return;
       }
       if (children.type && !types.has(children.type)) {
         types.set(children.type, true);
       }
-    }
+    };
 
     // extract components from children
     extract(this.props.children);
@@ -289,6 +291,7 @@ Story.propTypes = {
   context: React.PropTypes.object,
   info: React.PropTypes.string,
   propTables: React.PropTypes.arrayOf(React.PropTypes.func),
+  propTablesExclude: React.PropTypes.arrayOf(React.PropTypes.func),
   showInline: React.PropTypes.bool,
   showHeader: React.PropTypes.bool,
   showSource: React.PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ export default {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        propTablesExclude: options.propTablesExclude,
         mtrcConf
       };
 


### PR DESCRIPTION
This adds an option: **propTablesExclude**
To be used in **addWithInfo** like:
```
    ),
    { inline: true, propTables: [Button], propTablesExclude: [Container]}
  );
```

_Edit_: Also, **propTables** is not filtered by the exclude (because it happens before the collection of the children props) making it possible to include props that were excluded globally.