### PR TITLE
Add a isWrapped option to display the source of a child in case of HOC.

### DIFF
--- a/dist/components/Node.js
+++ b/dist/components/Node.js
@@ -56,11 +56,12 @@ var Node = function (_React$Component) {
   (0, _createClass3.default)(Node, [{
     key: 'render',
     value: function render() {
-      var _props = this.props;
-      var node = _props.node;
-      var depth = _props.depth;
-      var tagStyle = stylesheet.tagStyle;
-      var containerStyle = stylesheet.containerStyle;
+      var _props = this.props,
+          node = _props.node,
+          depth = _props.depth,
+          isWrapped = _props.isWrapped;
+      var tagStyle = stylesheet.tagStyle,
+          containerStyle = stylesheet.containerStyle;
 
 
       var leftPad = {
@@ -70,13 +71,13 @@ var Node = function (_React$Component) {
 
       (0, _assign2.default)(containerStyle, leftPad);
 
-      var _getData = getData(node);
-
-      var name = _getData.name;
-      var text = _getData.text;
-      var children = _getData.children;
+      var _getData = getData(node, isWrapped),
+          name = _getData.name,
+          text = _getData.text,
+          children = _getData.children;
 
       // Just text
+
 
       if (!name) {
         return _react2.default.createElement(
@@ -156,7 +157,7 @@ var Node = function (_React$Component) {
 exports.default = Node;
 
 
-function getData(element) {
+function getData(element, isWrapped) {
   var data = {
     name: null,
     text: null,
@@ -174,7 +175,8 @@ function getData(element) {
   }
 
   data.children = element.props.children;
-  var type = element.type;
+
+  var type = isWrapped ? element.type.wrapped : element.type;
 
   if (typeof type === 'string') {
     data.name = type;

--- a/dist/components/Props.js
+++ b/dist/components/Props.js
@@ -65,9 +65,9 @@ var Props = function (_React$Component) {
         return _react2.default.createElement('span', null);
       }
 
-      var propStyle = stylesheet.propStyle;
-      var propValueStyle = stylesheet.propValueStyle;
-      var propNameStyle = stylesheet.propNameStyle;
+      var propStyle = stylesheet.propStyle,
+          propValueStyle = stylesheet.propValueStyle,
+          propNameStyle = stylesheet.propNameStyle;
 
 
       var names = (0, _keys2.default)(props).filter(function (name) {

--- a/dist/components/Story.js
+++ b/dist/components/Story.js
@@ -301,6 +301,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_getSourceCode',
     value: function _getSourceCode() {
+      var _this3 = this;
+
       if (!this.props.showSource) {
         return null;
       }
@@ -317,7 +319,7 @@ var Story = function (_React$Component) {
           _markdown.Pre,
           null,
           _react2.default.Children.map(this.props.children, function (root, idx) {
-            return _react2.default.createElement(_Node2.default, { key: idx, depth: 0, node: root });
+            return _react2.default.createElement(_Node2.default, { key: idx, depth: 0, node: root, isWrapped: _this3.props.isWrapped });
           })
         )
       );

--- a/dist/components/markdown/code.js
+++ b/dist/components/markdown/code.js
@@ -40,6 +40,23 @@ var Code = exports.Code = function (_React$Component) {
   }
 
   (0, _createClass3.default)(Code, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      this.highlight();
+    }
+  }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate() {
+      this.highlight();
+    }
+  }, {
+    key: 'highlight',
+    value: function highlight() {
+      if (typeof Prism !== 'undefined') {
+        Prism.highlightAll();
+      }
+    }
+  }, {
     key: 'render',
     value: function render() {
       var codeStyle = {
@@ -55,12 +72,14 @@ var Code = exports.Code = function (_React$Component) {
         overflowX: 'scroll'
       };
 
+      var className = this.props.language ? 'language-' + this.props.language : '';
+
       return _react2.default.createElement(
         'pre',
-        { style: preStyle },
+        { style: preStyle, className: className },
         _react2.default.createElement(
           'code',
-          { style: codeStyle },
+          { style: codeStyle, className: className },
           this.props.code
         )
       );

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,7 +33,8 @@ var defaultOptions = {
   inline: false,
   header: true,
   source: true,
-  propTables: []
+  propTables: [],
+  isWrapped: false
 };
 
 var defaultMtrcConf = {
@@ -85,6 +86,7 @@ exports.default = {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        isWrapped: Boolean(options.isWrapped),
         mtrcConf: mtrcConf
       };
 

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -15,7 +15,7 @@ export default class Node extends React.Component {
   }
 
   render(){
-    const {node, depth} = this.props;
+    const {node, depth, isWrapped} = this.props;
     let {tagStyle, containerStyle} = stylesheet;
 
     var leftPad = {
@@ -25,7 +25,7 @@ export default class Node extends React.Component {
 
     Object.assign(containerStyle, leftPad);
 
-    const {name, text, children} = getData(node);
+    const {name, text, children} = getData(node, isWrapped);
 
     // Just text
     if (!name) {
@@ -65,7 +65,7 @@ export default class Node extends React.Component {
   }
 }
 
-function getData(element) {
+function getData(element, isWrapped) {
   const data = {
     name: null,
     text: null,
@@ -83,7 +83,8 @@ function getData(element) {
   }
 
   data.children = element.props.children;
-  const type = element.type;
+
+  const type = isWrapped ? element.type.wrapped : element.type;
 
   if (typeof type === 'string') {
     data.name = type;

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -200,7 +200,7 @@ export default class Story extends React.Component {
         <h1 style={stylesheet.source.h1}>Story Source</h1>
         <Pre>
         {React.Children.map(this.props.children, (root, idx) => (
-          <Node key={idx} depth={0} node={root} />
+          <Node key={idx} depth={0} node={root} isWrapped={this.props.isWrapped} />
         ))}
         </Pre>
       </div>
@@ -292,6 +292,7 @@ Story.propTypes = {
   showInline: React.PropTypes.bool,
   showHeader: React.PropTypes.bool,
   showSource: React.PropTypes.bool,
+  isWrapped: React.PropTypes.bool,
   children: React.PropTypes.oneOfType([
     React.PropTypes.object,
     React.PropTypes.array,
@@ -303,5 +304,6 @@ Story.defaultProps = {
   showInline: false,
   showHeader: true,
   showSource: true,
+  isWrapped: false,
   mtrcConf: {}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const defaultOptions = {
   header: true,
   source: true,
   propTables: [],
+  isWrapped: false,
 };
 
 const defaultMtrcConf = {
@@ -62,6 +63,7 @@ export default {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        isWrapped: Boolean(options.isWrapped),
         mtrcConf
       };
 


### PR DESCRIPTION
Sometimes the component you want to display in the storybook is exported together with its higher order component. That's the case when you use the `injectSheet` functionality of JSS for example.
In that case, the "Story Source" that is displayed using this plugin is probably not what you want, for example the output might be:
`<Jss(Button) text="Lorem ipsum" />`

This PR includes an additional boolean option called `isWrapped`. When it's true, it extracts the wrapped component source instead of the HOC. According to the previous example the result will be:
`<Button text="Lorem ipsum" />`

I am not sure this PR is generic enough to be accepted for this addon, I will wait for your feedbacks.
Thanks for this addon and for storybook project.
Awesome work!