### PR TITLE
Allow user to override styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/dist/components/Node.js
+++ b/dist/components/Node.js
@@ -4,33 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _assign = require('babel-runtime/core-js/object/assign');
-
-var _assign2 = _interopRequireDefault(_assign);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _merge3 = require('lodash/merge');
+
+var _merge4 = _interopRequireDefault(_merge3);
 
 var _Props = require('./Props');
 
@@ -38,45 +20,47 @@ var _Props2 = _interopRequireDefault(_Props);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var stylesheet = {
-  containerStyle: {},
-  tagStyle: {
-    color: '#777'
-  }
-};
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Node = function (_React$Component) {
-  (0, _inherits3.default)(Node, _React$Component);
+  _inherits(Node, _React$Component);
 
   function Node(props) {
-    (0, _classCallCheck3.default)(this, Node);
-    return (0, _possibleConstructorReturn3.default)(this, (Node.__proto__ || (0, _getPrototypeOf2.default)(Node)).call(this, props));
+    _classCallCheck(this, Node);
+
+    return _possibleConstructorReturn(this, (Node.__proto__ || Object.getPrototypeOf(Node)).call(this, props));
   }
 
-  (0, _createClass3.default)(Node, [{
+  _createClass(Node, [{
     key: 'render',
     value: function render() {
-      var _props = this.props;
-      var node = _props.node;
-      var depth = _props.depth;
-      var tagStyle = stylesheet.tagStyle;
-      var containerStyle = stylesheet.containerStyle;
+      var _props = this.props,
+          node = _props.node,
+          depth = _props.depth;
+      var storyStylesheet = this.context.storyStylesheet;
 
+      var _merge2 = (0, _merge4.default)({}, storyStylesheet.Node),
+          tagStyle = _merge2.tagStyle,
+          containerStyle = _merge2.containerStyle;
 
       var leftPad = {
         paddingLeft: 3 + (depth + 1) * 15,
         paddingRight: 3
       };
 
-      (0, _assign2.default)(containerStyle, leftPad);
+      Object.assign(containerStyle, leftPad);
 
-      var _getData = getData(node);
-
-      var name = _getData.name;
-      var text = _getData.text;
-      var children = _getData.children;
+      var _getData = getData(node),
+          name = _getData.name,
+          text = _getData.text,
+          children = _getData.children;
 
       // Just text
+
 
       if (!name) {
         return _react2.default.createElement(
@@ -111,7 +95,7 @@ var Node = function (_React$Component) {
       }
 
       // Keep a copy so that further mutations to containerStyle don't impact us:
-      var containerStyleCopy = (0, _assign2.default)({}, containerStyle);
+      var containerStyleCopy = Object.assign({}, containerStyle);
 
       // tag with children
       return _react2.default.createElement(
@@ -150,9 +134,13 @@ var Node = function (_React$Component) {
       );
     }
   }]);
+
   return Node;
 }(_react2.default.Component);
 
+Node.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
 exports.default = Node;
 
 

--- a/dist/components/PropTable.js
+++ b/dist/components/PropTable.js
@@ -4,33 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _values = require('babel-runtime/core-js/object/values');
-
-var _values2 = _interopRequireDefault(_values);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
-
-var _map = require('babel-runtime/core-js/map');
-
-var _map2 = _interopRequireDefault(_map);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -42,7 +16,13 @@ var _PropVal2 = _interopRequireDefault(_PropVal);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var PropTypesMap = new _map2.default();
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var PropTypesMap = new Map();
 for (var typeName in _react2.default.PropTypes) {
   if (!_react2.default.PropTypes.hasOwnProperty(typeName)) {
     continue;
@@ -52,26 +32,20 @@ for (var typeName in _react2.default.PropTypes) {
   PropTypesMap.set(type.isRequired, typeName);
 }
 
-var stylesheet = {
-  propTable: {
-    marginLeft: -10,
-    borderSpacing: '10px 5px',
-    borderCollapse: 'separate'
-  }
-};
-
 var PropTable = function (_React$Component) {
-  (0, _inherits3.default)(PropTable, _React$Component);
+  _inherits(PropTable, _React$Component);
 
   function PropTable() {
-    (0, _classCallCheck3.default)(this, PropTable);
-    return (0, _possibleConstructorReturn3.default)(this, (PropTable.__proto__ || (0, _getPrototypeOf2.default)(PropTable)).apply(this, arguments));
+    _classCallCheck(this, PropTable);
+
+    return _possibleConstructorReturn(this, (PropTable.__proto__ || Object.getPrototypeOf(PropTable)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(PropTable, [{
+  _createClass(PropTable, [{
     key: 'render',
     value: function render() {
       var type = this.props.type;
+      var stylesheet = this.context.storyStylesheet.PropTable;
 
       if (!type) {
         return null;
@@ -107,7 +81,7 @@ var PropTable = function (_React$Component) {
         }
       }
 
-      var array = (0, _values2.default)(props);
+      var array = Object.values(props);
       if (!array.length) {
         return _react2.default.createElement(
           'small',
@@ -121,7 +95,7 @@ var PropTable = function (_React$Component) {
 
       return _react2.default.createElement(
         'table',
-        { style: stylesheet.propTable },
+        { style: stylesheet.table },
         _react2.default.createElement(
           'thead',
           null,
@@ -183,9 +157,13 @@ var PropTable = function (_React$Component) {
       );
     }
   }]);
+
   return PropTable;
 }(_react2.default.Component);
 
+PropTable.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
 exports.default = PropTable;
 
 

--- a/dist/components/PropVal.js
+++ b/dist/components/PropVal.js
@@ -4,33 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
-
-var _typeof2 = require('babel-runtime/helpers/typeof');
-
-var _typeof3 = _interopRequireDefault(_typeof2);
-
-var _keys = require('babel-runtime/core-js/object/keys');
-
-var _keys2 = _interopRequireDefault(_keys);
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _react = require('react');
 
@@ -42,42 +18,13 @@ var _reactAddonsCreateFragment2 = _interopRequireDefault(_reactAddonsCreateFragm
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var valueStyles = {
-  func: {
-    color: '#170'
-  },
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  attr: {
-    color: '#666'
-  },
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  object: {
-    color: '#666'
-  },
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-  array: {
-    color: '#666'
-  },
-
-  number: {
-    color: '#a11'
-  },
-
-  string: {
-    color: '#22a',
-    wordBreak: 'break-word'
-  },
-
-  bool: {
-    color: '#a11'
-  },
-
-  empty: {
-    color: '#777'
-  }
-};
-
-function previewArray(val) {
+function previewArray(val, stylesheet) {
   var items = {};
   val.slice(0, 3).forEach(function (item, i) {
     items['n' + i] = _react2.default.createElement(PropVal, { val: item });
@@ -90,20 +37,20 @@ function previewArray(val) {
   }
   return _react2.default.createElement(
     'span',
-    { style: valueStyles.array },
+    { style: stylesheet.array },
     '[',
     (0, _reactAddonsCreateFragment2.default)(items),
     ']'
   );
 }
 
-function previewObject(val) {
-  var names = (0, _keys2.default)(val);
+function previewObject(val, stylesheet) {
+  var names = Object.keys(val);
   var items = {};
   names.slice(0, 3).forEach(function (name, i) {
     items['k' + i] = _react2.default.createElement(
       'span',
-      { style: valueStyles.attr },
+      { style: stylesheet.attr },
       name
     );
     items['c' + i] = ': ';
@@ -117,20 +64,20 @@ function previewObject(val) {
   }
   return _react2.default.createElement(
     'span',
-    { style: valueStyles.object },
+    { style: stylesheet.object },
     '{',
     (0, _reactAddonsCreateFragment2.default)(items),
     '}'
   );
 }
 
-function previewProp(val) {
+function previewProp(val, stylesheet) {
   var braceWrap = true;
   var content = null;
   if (typeof val === 'number') {
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.number },
+      { style: stylesheet.number },
       val
     );
   } else if (typeof val === 'string') {
@@ -139,7 +86,7 @@ function previewProp(val) {
     }
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.string },
+      { style: stylesheet.string },
       '"',
       val,
       '"'
@@ -148,24 +95,24 @@ function previewProp(val) {
   } else if (typeof val === 'boolean') {
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.bool },
+      { style: stylesheet.bool },
       '' + val
     );
   } else if (Array.isArray(val)) {
-    content = previewArray(val);
+    content = previewArray(val, stylesheet);
   } else if (typeof val === 'function') {
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.func },
+      { style: stylesheet.func },
       val.name ? val.name + '()' : 'anonymous()'
     );
   } else if (!val) {
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.empty },
+      { style: stylesheet.empty },
       '' + val
     );
-  } else if ((typeof val === 'undefined' ? 'undefined' : (0, _typeof3.default)(val)) !== 'object') {
+  } else if ((typeof val === 'undefined' ? 'undefined' : _typeof(val)) !== 'object') {
     content = _react2.default.createElement(
       'span',
       null,
@@ -174,11 +121,11 @@ function previewProp(val) {
   } else if (_react2.default.isValidElement(val)) {
     content = _react2.default.createElement(
       'span',
-      { style: valueStyles.object },
+      { style: stylesheet.object },
       '<' + (val.type.displayName || val.type.name || val.type) + ' />'
     );
   } else {
-    content = previewObject(val);
+    content = previewObject(val, stylesheet);
   }
 
   if (!braceWrap) return content;
@@ -192,22 +139,27 @@ function previewProp(val) {
 }
 
 var PropVal = function (_React$Component) {
-  (0, _inherits3.default)(PropVal, _React$Component);
+  _inherits(PropVal, _React$Component);
 
   function PropVal() {
-    (0, _classCallCheck3.default)(this, PropVal);
-    return (0, _possibleConstructorReturn3.default)(this, (PropVal.__proto__ || (0, _getPrototypeOf2.default)(PropVal)).apply(this, arguments));
+    _classCallCheck(this, PropVal);
+
+    return _possibleConstructorReturn(this, (PropVal.__proto__ || Object.getPrototypeOf(PropVal)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(PropVal, [{
+  _createClass(PropVal, [{
     key: 'render',
     value: function render() {
-      return previewProp(this.props.val);
+      return previewProp(this.props.val, this.context.storyStylesheet.PropVal);
     }
   }]);
+
   return PropVal;
 }(_react2.default.Component);
 
+PropVal.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
 exports.default = PropVal;
 
 

--- a/dist/components/Props.js
+++ b/dist/components/Props.js
@@ -4,33 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _keys = require('babel-runtime/core-js/object/keys');
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var _keys2 = _interopRequireDefault(_keys);
-
-var _typeof2 = require('babel-runtime/helpers/typeof');
-
-var _typeof3 = _interopRequireDefault(_typeof2);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -42,35 +18,39 @@ var _PropVal2 = _interopRequireDefault(_PropVal);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var stylesheet = {
-  propStyle: {},
-  propNameStyle: {},
-  propValueStyle: {}
-};
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Props = function (_React$Component) {
-  (0, _inherits3.default)(Props, _React$Component);
+  _inherits(Props, _React$Component);
 
   function Props() {
-    (0, _classCallCheck3.default)(this, Props);
-    return (0, _possibleConstructorReturn3.default)(this, (Props.__proto__ || (0, _getPrototypeOf2.default)(Props)).apply(this, arguments));
+    _classCallCheck(this, Props);
+
+    return _possibleConstructorReturn(this, (Props.__proto__ || Object.getPrototypeOf(Props)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(Props, [{
+  _createClass(Props, [{
     key: 'render',
     value: function render() {
       var props = this.props.node.props;
+      var storyStylesheet = this.context.storyStylesheet;
+
       var defaultProps = this.props.node.type.defaultProps;
-      if (!props || (typeof props === 'undefined' ? 'undefined' : (0, _typeof3.default)(props)) !== 'object') {
+      if (!props || (typeof props === 'undefined' ? 'undefined' : _typeof(props)) !== 'object') {
         return _react2.default.createElement('span', null);
       }
 
-      var propStyle = stylesheet.propStyle;
-      var propValueStyle = stylesheet.propValueStyle;
-      var propNameStyle = stylesheet.propNameStyle;
+      var _storyStylesheet$Prop = storyStylesheet.Props,
+          propStyle = _storyStylesheet$Prop.propStyle,
+          propValueStyle = _storyStylesheet$Prop.propValueStyle,
+          propNameStyle = _storyStylesheet$Prop.propNameStyle;
 
 
-      var names = (0, _keys2.default)(props).filter(function (name) {
+      var names = Object.keys(props).filter(function (name) {
         return name[0] !== '_' && name !== 'children' && (!defaultProps || props[name] != defaultProps[name]);
       });
 
@@ -114,7 +94,11 @@ var Props = function (_React$Component) {
       );
     }
   }]);
+
   return Props;
 }(_react2.default.Component);
 
+Props.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
 exports.default = Props;

--- a/dist/components/Story.js
+++ b/dist/components/Story.js
@@ -4,45 +4,17 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _from = require('babel-runtime/core-js/array/from');
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _from2 = _interopRequireDefault(_from);
-
-var _map = require('babel-runtime/core-js/map');
-
-var _map2 = _interopRequireDefault(_map);
-
-var _assign = require('babel-runtime/core-js/object/assign');
-
-var _assign2 = _interopRequireDefault(_assign);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
-
-var _extends2 = require('babel-runtime/helpers/extends');
-
-var _extends3 = _interopRequireDefault(_extends2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _merge2 = require('lodash/merge');
+
+var _merge3 = _interopRequireDefault(_merge2);
 
 var _markdownToReactComponents = require('markdown-to-react-components');
 
@@ -62,97 +34,52 @@ var _markdown = require('./markdown');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var stylesheet = {
-  link: {
-    base: {
-      fontFamily: 'sans-serif',
-      fontSize: '12px',
-      display: 'block',
-      position: 'fixed',
-      textDecoration: 'none',
-      background: '#28c',
-      color: '#fff',
-      padding: '5px 15px',
-      cursor: 'pointer'
-    },
-    topRight: {
-      top: 0,
-      right: 0,
-      borderRadius: '0 0 0 5px'
-    }
-  },
-  info: {
-    position: 'absolute',
-    background: 'white',
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    padding: '0 40px',
-    overflow: 'auto'
-  },
-  children: {
-    position: 'relative',
-    zIndex: 0
-  },
-  infoBody: (0, _extends3.default)({}, _theme.baseFonts, {
-    fontWeight: 300,
-    lineHeight: 1.45,
-    fontSize: '15px'
-  }),
-  infoContent: {
-    marginBottom: 0
-  },
-  header: {
-    h1: {
-      margin: '20px 0 0 0',
-      padding: 0,
-      fontSize: '35px'
-    },
-    h2: {
-      margin: '0 0 10px 0',
-      padding: 0,
-      fontWeight: 400,
-      fontSize: '22px'
-    },
-    body: {
-      borderBottom: '1px solid #eee',
-      marginBottom: 10
-    }
-  },
-  source: {
-    h1: {
-      margin: '20px 0 0 0',
-      padding: '0 0 5px 0',
-      fontSize: '25px',
-      borderBottom: '1px solid #EEE'
-    }
-  },
-  propTableHead: {
-    margin: '20px 0 0 0'
-  }
-};
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var Story = function (_React$Component) {
-  (0, _inherits3.default)(Story, _React$Component);
+  _inherits(Story, _React$Component);
 
-  function Story() {
+  function Story(props) {
     var _ref;
 
-    (0, _classCallCheck3.default)(this, Story);
+    _classCallCheck(this, Story);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
     }
 
-    var _this = (0, _possibleConstructorReturn3.default)(this, (_ref = Story.__proto__ || (0, _getPrototypeOf2.default)(Story)).call.apply(_ref, [this].concat(args)));
+    var _this = _possibleConstructorReturn(this, (_ref = Story.__proto__ || Object.getPrototypeOf(Story)).call.apply(_ref, [this, props].concat(args)));
 
-    _this.state = { open: false };
+    _this.state = {
+      open: false,
+      stylesheet: (0, _merge3.default)({}, _theme.baseStylesheet, props.stylesheet)
+    };
     _markdownToReactComponents2.default.configure(_this.props.mtrcConf);
     return _this;
   }
 
-  (0, _createClass3.default)(Story, [{
+  // pass down the stylesheet on context
+
+
+  _createClass(Story, [{
+    key: 'getChildContext',
+    value: function getChildContext() {
+      return {
+        storyStylesheet: this.state.stylesheet
+      };
+    }
+  }, {
+    key: 'getInfoBodyStyles',
+    value: function getInfoBodyStyles() {
+      var stylesheet = this.state.stylesheet;
+
+      return (0, _merge3.default)({}, stylesheet.baseFont, stylesheet.infoBody);
+    }
+  }, {
     key: '_renderStory',
     value: function _renderStory() {
       return _react2.default.createElement(
@@ -164,6 +91,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_renderInline',
     value: function _renderInline() {
+      var stylesheet = this.state.stylesheet;
+
       return _react2.default.createElement(
         'div',
         null,
@@ -172,7 +101,7 @@ var Story = function (_React$Component) {
           { style: stylesheet.infoPage },
           _react2.default.createElement(
             'div',
-            { style: stylesheet.infoBody },
+            { style: this.getInfoBodyStyles() },
             this._getInfoHeader()
           )
         ),
@@ -186,7 +115,7 @@ var Story = function (_React$Component) {
           { style: stylesheet.infoPage },
           _react2.default.createElement(
             'div',
-            { style: stylesheet.infoBody },
+            { style: this.getInfoBodyStyles() },
             this._getInfoContent(),
             this._getSourceCode(),
             this._getPropTables()
@@ -199,9 +128,11 @@ var Story = function (_React$Component) {
     value: function _renderOverlay() {
       var _this2 = this;
 
-      var linkStyle = (0, _extends3.default)({}, stylesheet.link.base, stylesheet.link.topRight);
+      var stylesheet = this.state.stylesheet;
 
-      var infoStyle = (0, _assign2.default)({}, stylesheet.info);
+      var linkStyle = _extends({}, stylesheet.link.base, stylesheet.link.topRight);
+
+      var infoStyle = Object.assign({}, stylesheet.info);
       if (!this.state.open) {
         infoStyle.display = 'none';
       }
@@ -242,7 +173,7 @@ var Story = function (_React$Component) {
             { style: stylesheet.infoPage },
             _react2.default.createElement(
               'div',
-              { style: stylesheet.infoBody },
+              { style: this.getInfoBodyStyles() },
               this._getInfoHeader(),
               this._getInfoContent(),
               this._getSourceCode(),
@@ -255,6 +186,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_getInfoHeader',
     value: function _getInfoHeader() {
+      var stylesheet = this.state.stylesheet;
+
       if (!this.props.context || !this.props.showHeader) {
         return null;
       }
@@ -277,6 +210,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_getInfoContent',
     value: function _getInfoContent() {
+      var stylesheet = this.state.stylesheet;
+
       if (!this.props.info) {
         return '';
       }
@@ -301,6 +236,8 @@ var Story = function (_React$Component) {
   }, {
     key: '_getSourceCode',
     value: function _getSourceCode() {
+      var stylesheet = this.state.stylesheet;
+
       if (!this.props.showSource) {
         return null;
       }
@@ -325,7 +262,7 @@ var Story = function (_React$Component) {
   }, {
     key: '_getPropTables',
     value: function _getPropTables() {
-      var types = new _map2.default();
+      var types = new Map();
 
       if (this.props.propTables === null) {
         return null;
@@ -364,10 +301,12 @@ var Story = function (_React$Component) {
       // extract components from children
       extract(this.props.children);
 
-      var array = (0, _from2.default)(types.keys());
+      var array = Array.from(types.keys());
       array.sort(function (a, b) {
         return (a.displayName || a.name) > (b.displayName || b.name);
       });
+
+      var stylesheet = this.state.stylesheet;
 
       var propTables = array.map(function (type, idx) {
         return _react2.default.createElement(
@@ -398,8 +337,6 @@ var Story = function (_React$Component) {
         ),
         propTables
       );
-
-      return;
     }
   }, {
     key: 'render',
@@ -411,9 +348,13 @@ var Story = function (_React$Component) {
       return this._renderOverlay();
     }
   }]);
+
   return Story;
 }(_react2.default.Component);
 
+Story.childContextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
 exports.default = Story;
 
 
@@ -426,6 +367,7 @@ Story.propTypes = {
   showHeader: _react2.default.PropTypes.bool,
   showSource: _react2.default.PropTypes.bool,
   children: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.object, _react2.default.PropTypes.array]),
+  stylesheet: _react2.default.PropTypes.object,
   mtrcConf: _react2.default.PropTypes.object
 };
 

--- a/dist/components/markdown/code.js
+++ b/dist/components/markdown/code.js
@@ -5,25 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Blockquote = exports.Pre = exports.Code = undefined;
 
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -31,15 +13,39 @@ var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var Code = exports.Code = function (_React$Component) {
-  (0, _inherits3.default)(Code, _React$Component);
+  _inherits(Code, _React$Component);
 
   function Code() {
-    (0, _classCallCheck3.default)(this, Code);
-    return (0, _possibleConstructorReturn3.default)(this, (Code.__proto__ || (0, _getPrototypeOf2.default)(Code)).apply(this, arguments));
+    _classCallCheck(this, Code);
+
+    return _possibleConstructorReturn(this, (Code.__proto__ || Object.getPrototypeOf(Code)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(Code, [{
+  _createClass(Code, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      this.highlight();
+    }
+  }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate() {
+      this.highlight();
+    }
+  }, {
+    key: 'highlight',
+    value: function highlight() {
+      if (typeof Prism !== 'undefined') {
+        Prism.highlightAll();
+      }
+    }
+  }, {
     key: 'render',
     value: function render() {
       var codeStyle = {
@@ -55,29 +61,33 @@ var Code = exports.Code = function (_React$Component) {
         overflowX: 'scroll'
       };
 
+      var className = this.props.language ? 'language-' + this.props.language : '';
+
       return _react2.default.createElement(
         'pre',
-        { style: preStyle },
+        { style: preStyle, className: className },
         _react2.default.createElement(
           'code',
-          { style: codeStyle },
+          { style: codeStyle, className: className },
           this.props.code
         )
       );
     }
   }]);
+
   return Code;
 }(_react2.default.Component);
 
 var Pre = exports.Pre = function (_React$Component2) {
-  (0, _inherits3.default)(Pre, _React$Component2);
+  _inherits(Pre, _React$Component2);
 
   function Pre() {
-    (0, _classCallCheck3.default)(this, Pre);
-    return (0, _possibleConstructorReturn3.default)(this, (Pre.__proto__ || (0, _getPrototypeOf2.default)(Pre)).apply(this, arguments));
+    _classCallCheck(this, Pre);
+
+    return _possibleConstructorReturn(this, (Pre.__proto__ || Object.getPrototypeOf(Pre)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(Pre, [{
+  _createClass(Pre, [{
     key: 'render',
     value: function render() {
       var style = {
@@ -96,18 +106,20 @@ var Pre = exports.Pre = function (_React$Component2) {
       );
     }
   }]);
+
   return Pre;
 }(_react2.default.Component);
 
 var Blockquote = exports.Blockquote = function (_React$Component3) {
-  (0, _inherits3.default)(Blockquote, _React$Component3);
+  _inherits(Blockquote, _React$Component3);
 
   function Blockquote() {
-    (0, _classCallCheck3.default)(this, Blockquote);
-    return (0, _possibleConstructorReturn3.default)(this, (Blockquote.__proto__ || (0, _getPrototypeOf2.default)(Blockquote)).apply(this, arguments));
+    _classCallCheck(this, Blockquote);
+
+    return _possibleConstructorReturn(this, (Blockquote.__proto__ || Object.getPrototypeOf(Blockquote)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(Blockquote, [{
+  _createClass(Blockquote, [{
     key: 'render',
     value: function render() {
       var style = {
@@ -124,5 +136,6 @@ var Blockquote = exports.Blockquote = function (_React$Component3) {
       );
     }
   }]);
+
   return Blockquote;
 }(_react2.default.Component);

--- a/dist/components/markdown/htags.js
+++ b/dist/components/markdown/htags.js
@@ -5,50 +5,35 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.H6 = exports.H5 = exports.H4 = exports.H3 = exports.H2 = exports.H1 = undefined;
 
-var _extends2 = require('babel-runtime/helpers/extends');
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _extends3 = _interopRequireDefault(_extends2);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _theme = require('../theme');
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var H1 = exports.H1 = function (_React$Component) {
-  (0, _inherits3.default)(H1, _React$Component);
+  _inherits(H1, _React$Component);
 
   function H1() {
-    (0, _classCallCheck3.default)(this, H1);
-    return (0, _possibleConstructorReturn3.default)(this, (H1.__proto__ || (0, _getPrototypeOf2.default)(H1)).apply(this, arguments));
+    _classCallCheck(this, H1);
+
+    return _possibleConstructorReturn(this, (H1.__proto__ || Object.getPrototypeOf(H1)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H1, [{
+  _createClass(H1, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         borderBottom: '1px solid #eee',
         fontWeight: 600,
         margin: 0,
@@ -63,21 +48,27 @@ var H1 = exports.H1 = function (_React$Component) {
       );
     }
   }]);
+
   return H1;
 }(_react2.default.Component);
 
+H1.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var H2 = exports.H2 = function (_React$Component2) {
-  (0, _inherits3.default)(H2, _React$Component2);
+  _inherits(H2, _React$Component2);
 
   function H2() {
-    (0, _classCallCheck3.default)(this, H2);
-    return (0, _possibleConstructorReturn3.default)(this, (H2.__proto__ || (0, _getPrototypeOf2.default)(H2)).apply(this, arguments));
+    _classCallCheck(this, H2);
+
+    return _possibleConstructorReturn(this, (H2.__proto__ || Object.getPrototypeOf(H2)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H2, [{
+  _createClass(H2, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         fontWeight: 600,
         margin: 0,
         padding: 0,
@@ -91,21 +82,27 @@ var H2 = exports.H2 = function (_React$Component2) {
       );
     }
   }]);
+
   return H2;
 }(_react2.default.Component);
 
+H2.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var H3 = exports.H3 = function (_React$Component3) {
-  (0, _inherits3.default)(H3, _React$Component3);
+  _inherits(H3, _React$Component3);
 
   function H3() {
-    (0, _classCallCheck3.default)(this, H3);
-    return (0, _possibleConstructorReturn3.default)(this, (H3.__proto__ || (0, _getPrototypeOf2.default)(H3)).apply(this, arguments));
+    _classCallCheck(this, H3);
+
+    return _possibleConstructorReturn(this, (H3.__proto__ || Object.getPrototypeOf(H3)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H3, [{
+  _createClass(H3, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         fontWeight: 600,
         margin: 0,
         padding: 0,
@@ -120,21 +117,27 @@ var H3 = exports.H3 = function (_React$Component3) {
       );
     }
   }]);
+
   return H3;
 }(_react2.default.Component);
 
+H3.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var H4 = exports.H4 = function (_React$Component4) {
-  (0, _inherits3.default)(H4, _React$Component4);
+  _inherits(H4, _React$Component4);
 
   function H4() {
-    (0, _classCallCheck3.default)(this, H4);
-    return (0, _possibleConstructorReturn3.default)(this, (H4.__proto__ || (0, _getPrototypeOf2.default)(H4)).apply(this, arguments));
+    _classCallCheck(this, H4);
+
+    return _possibleConstructorReturn(this, (H4.__proto__ || Object.getPrototypeOf(H4)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H4, [{
+  _createClass(H4, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         fontWeight: 600,
         margin: 0,
         padding: 0,
@@ -148,21 +151,27 @@ var H4 = exports.H4 = function (_React$Component4) {
       );
     }
   }]);
+
   return H4;
 }(_react2.default.Component);
 
+H4.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var H5 = exports.H5 = function (_React$Component5) {
-  (0, _inherits3.default)(H5, _React$Component5);
+  _inherits(H5, _React$Component5);
 
   function H5() {
-    (0, _classCallCheck3.default)(this, H5);
-    return (0, _possibleConstructorReturn3.default)(this, (H5.__proto__ || (0, _getPrototypeOf2.default)(H5)).apply(this, arguments));
+    _classCallCheck(this, H5);
+
+    return _possibleConstructorReturn(this, (H5.__proto__ || Object.getPrototypeOf(H5)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H5, [{
+  _createClass(H5, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         fontWeight: 600,
         margin: 0,
         padding: 0,
@@ -176,21 +185,27 @@ var H5 = exports.H5 = function (_React$Component5) {
       );
     }
   }]);
+
   return H5;
 }(_react2.default.Component);
 
+H5.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var H6 = exports.H6 = function (_React$Component6) {
-  (0, _inherits3.default)(H6, _React$Component6);
+  _inherits(H6, _React$Component6);
 
   function H6() {
-    (0, _classCallCheck3.default)(this, H6);
-    return (0, _possibleConstructorReturn3.default)(this, (H6.__proto__ || (0, _getPrototypeOf2.default)(H6)).apply(this, arguments));
+    _classCallCheck(this, H6);
+
+    return _possibleConstructorReturn(this, (H6.__proto__ || Object.getPrototypeOf(H6)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(H6, [{
+  _createClass(H6, [{
     key: 'render',
     value: function render() {
-      var styles = (0, _extends3.default)({}, _theme.baseFonts, {
+      var styles = _extends({}, this.context.storyStylesheet.baseFont, {
         fontWeight: 400,
         margin: 0,
         padding: 0,
@@ -204,5 +219,10 @@ var H6 = exports.H6 = function (_React$Component6) {
       );
     }
   }]);
+
   return H6;
 }(_react2.default.Component);
+
+H6.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};

--- a/dist/components/markdown/text.js
+++ b/dist/components/markdown/text.js
@@ -5,50 +5,35 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.A = exports.UL = exports.LI = exports.P = undefined;
 
-var _extends2 = require('babel-runtime/helpers/extends');
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _extends3 = _interopRequireDefault(_extends2);
-
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
-
-var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
-
-var _createClass2 = require('babel-runtime/helpers/createClass');
-
-var _createClass3 = _interopRequireDefault(_createClass2);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _theme = require('../theme');
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var P = exports.P = function (_React$Component) {
-  (0, _inherits3.default)(P, _React$Component);
+  _inherits(P, _React$Component);
 
   function P() {
-    (0, _classCallCheck3.default)(this, P);
-    return (0, _possibleConstructorReturn3.default)(this, (P.__proto__ || (0, _getPrototypeOf2.default)(P)).apply(this, arguments));
+    _classCallCheck(this, P);
+
+    return _possibleConstructorReturn(this, (P.__proto__ || Object.getPrototypeOf(P)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(P, [{
+  _createClass(P, [{
     key: 'render',
     value: function render() {
-      var style = (0, _extends3.default)({}, _theme.baseFonts, {
+      var style = _extends({}, this.context.storyStylesheet.baseFont, {
         fontSize: '15px'
       });
       return _react2.default.createElement(
@@ -58,21 +43,27 @@ var P = exports.P = function (_React$Component) {
       );
     }
   }]);
+
   return P;
 }(_react2.default.Component);
 
+P.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var LI = exports.LI = function (_React$Component2) {
-  (0, _inherits3.default)(LI, _React$Component2);
+  _inherits(LI, _React$Component2);
 
   function LI() {
-    (0, _classCallCheck3.default)(this, LI);
-    return (0, _possibleConstructorReturn3.default)(this, (LI.__proto__ || (0, _getPrototypeOf2.default)(LI)).apply(this, arguments));
+    _classCallCheck(this, LI);
+
+    return _possibleConstructorReturn(this, (LI.__proto__ || Object.getPrototypeOf(LI)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(LI, [{
+  _createClass(LI, [{
     key: 'render',
     value: function render() {
-      var style = (0, _extends3.default)({}, _theme.baseFonts, {
+      var style = _extends({}, this.context.storyStylesheet.baseFont, {
         fontSize: '15px'
       });
       return _react2.default.createElement(
@@ -82,21 +73,27 @@ var LI = exports.LI = function (_React$Component2) {
       );
     }
   }]);
+
   return LI;
 }(_react2.default.Component);
 
+LI.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var UL = exports.UL = function (_React$Component3) {
-  (0, _inherits3.default)(UL, _React$Component3);
+  _inherits(UL, _React$Component3);
 
   function UL() {
-    (0, _classCallCheck3.default)(this, UL);
-    return (0, _possibleConstructorReturn3.default)(this, (UL.__proto__ || (0, _getPrototypeOf2.default)(UL)).apply(this, arguments));
+    _classCallCheck(this, UL);
+
+    return _possibleConstructorReturn(this, (UL.__proto__ || Object.getPrototypeOf(UL)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(UL, [{
+  _createClass(UL, [{
     key: 'render',
     value: function render() {
-      var style = (0, _extends3.default)({}, _theme.baseFonts, {
+      var style = _extends({}, this.context.storyStylesheet.baseFont, {
         fontSize: '15px'
       });
 
@@ -107,18 +104,24 @@ var UL = exports.UL = function (_React$Component3) {
       );
     }
   }]);
+
   return UL;
 }(_react2.default.Component);
 
+UL.contextTypes = {
+  storyStylesheet: _react2.default.PropTypes.object
+};
+
 var A = exports.A = function (_React$Component4) {
-  (0, _inherits3.default)(A, _React$Component4);
+  _inherits(A, _React$Component4);
 
   function A() {
-    (0, _classCallCheck3.default)(this, A);
-    return (0, _possibleConstructorReturn3.default)(this, (A.__proto__ || (0, _getPrototypeOf2.default)(A)).apply(this, arguments));
+    _classCallCheck(this, A);
+
+    return _possibleConstructorReturn(this, (A.__proto__ || Object.getPrototypeOf(A)).apply(this, arguments));
   }
 
-  (0, _createClass3.default)(A, [{
+  _createClass(A, [{
     key: 'render',
     value: function render() {
       var style = {
@@ -132,5 +135,6 @@ var A = exports.A = function (_React$Component4) {
       );
     }
   }]);
+
   return A;
 }(_react2.default.Component);

--- a/dist/components/theme.js
+++ b/dist/components/theme.js
@@ -3,8 +3,149 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var baseFonts = exports.baseFonts = {
-  fontFamily: '\n    -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto",\n    "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif\n  ',
-  color: '#444',
-  WebkitFontSmoothing: 'antialiased'
+
+/*
+ styles can be overridden by the user in setDefaults:
+
+ setDefaults(
+   inline: true,
+   stylesheet: {
+     header: {h1: {color: 'orange'}},
+     PropVal: {string: {color: 'red'}}
+   }
+ );
+*/
+var baseStylesheet = exports.baseStylesheet = {
+  baseFont: {
+    fontFamily: '\n    -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto",\n    "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif\n  ',
+    color: '#444',
+    WebkitFontSmoothing: 'antialiased'
+  },
+  link: {
+    base: {
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      display: 'block',
+      position: 'fixed',
+      textDecoration: 'none',
+      background: '#28c',
+      color: '#fff',
+      padding: '5px 15px',
+      cursor: 'pointer'
+    },
+    topRight: {
+      top: 0,
+      right: 0,
+      borderRadius: '0 0 0 5px'
+    }
+  },
+  info: {
+    position: 'absolute',
+    background: 'white',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: '0 40px',
+    overflow: 'auto'
+  },
+  children: {
+    position: 'relative',
+    zIndex: 0
+  },
+  infoBody: {
+    fontWeight: 300,
+    lineHeight: 1.45,
+    fontSize: '15px'
+  },
+  infoContent: {
+    marginBottom: 0
+  },
+  header: {
+    h1: {
+      margin: '20px 0 0 0',
+      padding: 0,
+      fontSize: '35px',
+      color: 'blue'
+    },
+    h2: {
+      margin: '0 0 10px 0',
+      padding: 0,
+      fontWeight: 400,
+      fontSize: '22px',
+      color: 'green'
+    },
+    body: {
+      borderBottom: '1px solid #eee',
+      marginBottom: 10
+    }
+  },
+  source: {
+    h1: {
+      margin: '20px 0 0 0',
+      padding: '0 0 5px 0',
+      fontSize: '25px',
+      borderBottom: '1px solid #EEE'
+    }
+  },
+  propTableHead: {
+    margin: '20px 0 0 0'
+  },
+
+  // components
+  Node: {
+    containerStyle: {},
+    tagStyle: {
+      color: '#777'
+    }
+  },
+
+  Props: {
+    propStyle: {// currently unused
+    },
+    propNameStyle: {},
+    propValueStyle: {}
+  },
+
+  PropVal: {
+    func: {
+      color: '#170'
+    },
+
+    attr: {
+      color: '#666'
+    },
+
+    object: {
+      color: '#666'
+    },
+
+    array: {
+      color: '#666'
+    },
+
+    number: {
+      color: '#a11'
+    },
+
+    string: {
+      color: '#22a',
+      wordBreak: 'break-word'
+    },
+
+    bool: {
+      color: '#a11'
+    },
+
+    empty: {
+      color: '#777'
+    }
+  },
+  PropTable: {
+    table: {
+      marginLeft: -10,
+      borderSpacing: '10px 5px',
+      borderCollapse: 'separate'
+    }
+  }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,13 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Story = undefined;
 
-var _assign = require('babel-runtime/core-js/object/assign');
-
-var _assign2 = _interopRequireDefault(_assign);
-
-var _extends2 = require('babel-runtime/helpers/extends');
-
-var _extends3 = _interopRequireDefault(_extends2);
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.setDefaults = setDefaults;
 
@@ -63,7 +57,7 @@ exports.default = {
       }
     }
 
-    var options = (0, _extends3.default)({}, defaultOptions, _options);
+    var options = _extends({}, defaultOptions, _options);
 
     // props.propTables can only be either an array of components or null
     // propTables option is allowed to be set to 'false' (a boolean)
@@ -72,9 +66,9 @@ exports.default = {
       options.propTables = null;
     }
 
-    var mtrcConf = (0, _extends3.default)({}, defaultMtrcConf);
+    var mtrcConf = _extends({}, defaultMtrcConf);
     if (options && options.mtrcConf) {
-      (0, _assign2.default)(mtrcConf, options.mtrcConf);
+      Object.assign(mtrcConf, options.mtrcConf);
     }
 
     return this.add(storyName, function (context) {
@@ -85,6 +79,7 @@ exports.default = {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        stylesheet: options.stylesheet,
         mtrcConf: mtrcConf
       };
 
@@ -97,5 +92,5 @@ exports.default = {
   }
 };
 function setDefaults(newDefaults) {
-  return (0, _assign2.default)(defaultOptions, newDefaults);
+  return Object.assign(defaultOptions, newDefaults);
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm run lint && npm run testonly",
     "test-watch": "npm run testonly -- --watch --watch-extensions js",
     "storybook": "start-storybook -p 9010",
-    "publish-storybook": "bash .scripts/publish_storybook.sh"
+    "publish-storybook": "bash .scripts/publish_storybook.sh",
+    "build": "babel src --out-dir dist"
   },
   "devDependencies": {
     "@kadira/storybook": "^2.20.1",

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -1,22 +1,20 @@
 import React from 'react';
+import _merge from 'lodash/merge';
 import Props from './Props'
-
-
-const stylesheet = {
-  containerStyle: {},
-  tagStyle: {
-    color: '#777',
-  }
-}
 
 export default class Node extends React.Component {
   constructor(props){
     super(props);
   }
 
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render(){
     const {node, depth} = this.props;
-    let {tagStyle, containerStyle} = stylesheet;
+    const {storyStylesheet} = this.context;
+    let {tagStyle, containerStyle} = _merge({}, storyStylesheet.Node);
 
     var leftPad = {
       paddingLeft: 3 + (depth + 1) * 15,

--- a/src/components/PropTable.js
+++ b/src/components/PropTable.js
@@ -11,17 +11,16 @@ for (const typeName in React.PropTypes) {
   PropTypesMap.set(type.isRequired, typeName);
 }
 
-const stylesheet = {
-  propTable: {
-    marginLeft: -10,
-    borderSpacing: '10px 5px',
-    borderCollapse: 'separate',
-  },
-};
 
 export default class PropTable extends React.Component {
+
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const type = this.props.type;
+    const stylesheet = this.context.storyStylesheet.PropTable;
 
     if (!type) {
       return null;
@@ -66,7 +65,7 @@ export default class PropTable extends React.Component {
     });
 
     return (
-      <table style={stylesheet.propTable}>
+      <table style={stylesheet.table}>
         <thead>
           <tr>
             <th>property</th>

--- a/src/components/PropVal.js
+++ b/src/components/PropVal.js
@@ -1,42 +1,7 @@
 import React from 'react';
 import createFragment from 'react-addons-create-fragment';
 
-const valueStyles = {
-  func: {
-    color: '#170',
-  },
-
-  attr: {
-    color: '#666',
-  },
-
-  object: {
-    color: '#666',
-  },
-
-  array: {
-    color: '#666',
-  },
-
-  number: {
-    color: '#a11',
-  },
-
-  string: {
-    color: '#22a',
-    wordBreak: 'break-word',
-  },
-
-  bool: {
-    color: '#a11',
-  },
-
-  empty: {
-    color: '#777',
-  },
-};
-
-function previewArray(val) {
+function previewArray(val, stylesheet) {
   const items = {};
   val.slice(0, 3).forEach((item, i) => {
     items[`n${i}`] = <PropVal val={item} />;
@@ -48,17 +13,17 @@ function previewArray(val) {
     delete items[`c${val.length - 1}`];
   }
   return (
-    <span style={valueStyles.array}>
+    <span style={stylesheet.array}>
       [{createFragment(items)}]
     </span>
   );
 }
 
-function previewObject(val) {
+function previewObject(val, stylesheet) {
   const names = Object.keys(val);
   const items = {};
   names.slice(0, 3).forEach((name, i) => {
-    items[`k${i}`] = <span style={valueStyles.attr}>{name}</span>;
+    items[`k${i}`] = <span style={stylesheet.attr}>{name}</span>;
     items[`c${i}`] = ': ';
     items[`v${i}`] = <PropVal val={val[name]} />;
     items[`m${i}`] = ', ';
@@ -69,41 +34,41 @@ function previewObject(val) {
     delete items[`m${names.length - 1}`];
   }
   return (
-    <span style={valueStyles.object}>
+    <span style={stylesheet.object}>
       {'{'}{createFragment(items)}{'}'}
     </span>
   );
 }
 
-function previewProp(val) {
+function previewProp(val, stylesheet) {
   let braceWrap = true;
   let content = null;
   if (typeof val === 'number') {
-    content = <span style={valueStyles.number}>{val}</span>;
+    content = <span style={stylesheet.number}>{val}</span>;
   } else if (typeof val === 'string') {
     if (val.length > 50) {
       val = val.slice(0, 50) + '…';
     }
-    content = <span style={valueStyles.string}>"{val}"</span>;
+    content = <span style={stylesheet.string}>"{val}"</span>;
     braceWrap = false;
   } else if (typeof val === 'boolean') {
-    content = <span style={valueStyles.bool}>{`${val}`}</span>;
+    content = <span style={stylesheet.bool}>{`${val}`}</span>;
   } else if (Array.isArray(val)) {
-    content = previewArray(val);
+    content = previewArray(val, stylesheet);
   } else if (typeof val === 'function') {
-    content = <span style={valueStyles.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
+    content = <span style={stylesheet.func}>{val.name ? `${val.name}()` : 'anonymous()'}</span>;
   } else if (!val) {
-    content = <span style={valueStyles.empty}>{`${val}`}</span>;
+    content = <span style={stylesheet.empty}>{`${val}`}</span>;
   } else if (typeof val !== 'object') {
     content = <span>…</span>;
   } else if (React.isValidElement(val)) {
     content = (
-      <span style={valueStyles.object}>
+      <span style={stylesheet.object}>
         {`<${val.type.displayName || val.type.name || val.type} />`}
       </span>
     );
   } else {
-    content = previewObject(val);
+    content = previewObject(val, stylesheet);
   }
 
   if (!braceWrap) return content;
@@ -111,8 +76,13 @@ function previewProp(val) {
 }
 
 export default class PropVal extends React.Component {
+
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
-    return previewProp(this.props.val);
+    return previewProp(this.props.val, this.context.storyStylesheet.PropVal);
   }
 }
 

--- a/src/components/Props.js
+++ b/src/components/Props.js
@@ -1,24 +1,22 @@
 import React from 'react';
 import PropVal from './PropVal';
 
-const stylesheet = {
-  propStyle: {
-  },
-  propNameStyle: {
-  },
-  propValueStyle: {
-  }
-}
 
 export default class Props extends React.Component {
+
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const props = this.props.node.props;
+    const {storyStylesheet} = this.context;
     const defaultProps = this.props.node.type.defaultProps;
     if (!props || typeof props !== 'object') {
       return <span />;
     }
 
-    const {propStyle, propValueStyle, propNameStyle} = stylesheet;
+    const {propStyle, propValueStyle, propNameStyle} = storyStylesheet.Props;
 
     const names = Object.keys(props).filter(name => {
       return name[0] !== '_' && name !== 'children' && (!defaultProps || props[name] != defaultProps[name]);

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -1,87 +1,36 @@
 import React from 'react';
+import _merge from 'lodash/merge';
 import MTRC from 'markdown-to-react-components';
 import PropTable from './PropTable';
 import Node from './Node';
-import { baseFonts } from './theme';
+import { baseStylesheet } from './theme';
 import { Pre } from './markdown';
 
-const stylesheet = {
-  link: {
-    base: {
-      fontFamily: 'sans-serif',
-      fontSize: '12px',
-      display: 'block',
-      position: 'fixed',
-      textDecoration: 'none',
-      background: '#28c',
-      color: '#fff',
-      padding: '5px 15px',
-      cursor: 'pointer',
-    },
-    topRight: {
-      top: 0,
-      right: 0,
-      borderRadius: '0 0 0 5px',
-    },
-  },
-  info: {
-    position: 'absolute',
-    background: 'white',
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    padding: '0 40px',
-    overflow: 'auto',
-  },
-  children: {
-    position: 'relative',
-    zIndex: 0,
-  },
-  infoBody: {
-    ...baseFonts,
-    fontWeight: 300,
-    lineHeight: 1.45,
-    fontSize: '15px',
-  },
-  infoContent: {
-    marginBottom: 0,
-  },
-  header: {
-    h1: {
-      margin: '20px 0 0 0',
-      padding: 0,
-      fontSize: '35px',
-    },
-    h2: {
-      margin: '0 0 10px 0',
-      padding: 0,
-      fontWeight: 400,
-      fontSize: '22px',
-    },
-    body: {
-      borderBottom: '1px solid #eee',
-      marginBottom: 10,
-    },
-  },
-  source: {
-    h1: {
-      margin: '20px 0 0 0',
-      padding: '0 0 5px 0',
-      fontSize: '25px',
-      borderBottom: '1px solid #EEE',
-    },
-  },
-  propTableHead: {
-    margin: '20px 0 0 0',
-  },
-};
 
 export default class Story extends React.Component {
-  constructor(...args) {
-    super(...args);
-    this.state = { open: false };
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.state = {
+      open: false,
+      stylesheet: _merge({}, baseStylesheet, props.stylesheet)
+    };
     MTRC.configure(this.props.mtrcConf);
+  }
+
+  // pass down the stylesheet on context
+  static childContextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
+  getChildContext() {
+    return {
+      storyStylesheet: this.state.stylesheet
+    };
+  }
+
+  getInfoBodyStyles() {
+    const {stylesheet} = this.state;
+    return _merge({}, stylesheet.baseFont, stylesheet.infoBody);
   }
 
   _renderStory() {
@@ -93,10 +42,11 @@ export default class Story extends React.Component {
   }
 
   _renderInline() {
+    const {stylesheet} = this.state;
     return (
       <div>
         <div style={stylesheet.infoPage}>
-          <div style={stylesheet.infoBody} >
+          <div style={this.getInfoBodyStyles()} >
             { this._getInfoHeader() }
           </div>
         </div>
@@ -104,7 +54,7 @@ export default class Story extends React.Component {
             { this._renderStory() }
         </div>
         <div style={stylesheet.infoPage}>
-          <div style={stylesheet.infoBody} >
+          <div style={this.getInfoBodyStyles()} >
             { this._getInfoContent() }
             { this._getSourceCode() }
             { this._getPropTables() }
@@ -115,6 +65,7 @@ export default class Story extends React.Component {
   }
 
   _renderOverlay() {
+    const {stylesheet} = this.state;
     const linkStyle = {
       ...stylesheet.link.base,
       ...stylesheet.link.topRight,
@@ -144,7 +95,7 @@ export default class Story extends React.Component {
         <div style={infoStyle}>
           <a style={linkStyle} onClick={closeOverlay}>×</a>
           <div style={stylesheet.infoPage}>
-            <div style={stylesheet.infoBody}>
+            <div style={this.getInfoBodyStyles()}>
               { this._getInfoHeader() }
               { this._getInfoContent() }
               { this._getSourceCode() }
@@ -157,6 +108,7 @@ export default class Story extends React.Component {
   }
 
   _getInfoHeader() {
+    const {stylesheet} = this.state;
     if (!this.props.context || !this.props.showHeader) {
       return null;
     }
@@ -170,6 +122,7 @@ export default class Story extends React.Component {
   }
 
   _getInfoContent() {
+    const {stylesheet} = this.state;
     if (!this.props.info) {
       return '';
     }
@@ -191,6 +144,7 @@ export default class Story extends React.Component {
   }
 
   _getSourceCode() {
+    const {stylesheet} = this.state;
     if (!this.props.showSource) {
       return null;
     }
@@ -252,6 +206,7 @@ export default class Story extends React.Component {
       return (a.displayName || a.name) > (b.displayName || b.name);
     });
 
+    const {stylesheet} = this.state;
     const propTables = array.map(function (type, idx) {
       return (
         <div key={idx}>
@@ -271,8 +226,6 @@ export default class Story extends React.Component {
         {propTables}
       </div>
     );
-
-    return;
   }
 
   render() {
@@ -296,6 +249,7 @@ Story.propTypes = {
     React.PropTypes.object,
     React.PropTypes.array,
   ]),
+  stylesheet: React.PropTypes.object,
   mtrcConf: React.PropTypes.object
 };
 

--- a/src/components/markdown/htags.js
+++ b/src/components/markdown/htags.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { baseFonts } from '../theme';
 
 export class H1 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       borderBottom: '1px solid #eee',
       fontWeight: 600,
       margin: 0,
@@ -17,9 +20,13 @@ export class H1 extends React.Component {
 }
 
 export class H2 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontWeight: 600,
       margin: 0,
       padding: 0,
@@ -31,9 +38,13 @@ export class H2 extends React.Component {
 }
 
 export class H3 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontWeight: 600,
       margin: 0,
       padding: 0,
@@ -46,9 +57,13 @@ export class H3 extends React.Component {
 }
 
 export class H4 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontWeight: 600,
       margin: 0,
       padding: 0,
@@ -60,9 +75,13 @@ export class H4 extends React.Component {
 }
 
 export class H5 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontWeight: 600,
       margin: 0,
       padding: 0,
@@ -74,9 +93,13 @@ export class H5 extends React.Component {
 }
 
 export class H6 extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
+
   render() {
     const styles = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontWeight: 400,
       margin: 0,
       padding: 0,

--- a/src/components/markdown/text.js
+++ b/src/components/markdown/text.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { baseFonts } from '../theme';
 
 export class P extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
   render() {
     const style = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontSize: '15px',
     };
     return <p style={style}>{this.props.children}</p>;
@@ -12,9 +14,12 @@ export class P extends React.Component {
 }
 
 export class LI extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
   render() {
     const style = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontSize: '15px',
     };
     return <li style={style}>{this.props.children}</li>;
@@ -22,9 +27,12 @@ export class LI extends React.Component {
 }
 
 export class UL extends React.Component {
+  static contextTypes = {
+    storyStylesheet: React.PropTypes.object
+  };
   render() {
     const style = {
-      ...baseFonts,
+      ...this.context.storyStylesheet.baseFont,
       fontSize: '15px',
     };
 

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -63,15 +63,13 @@ export const baseStylesheet = {
     h1: {
       margin: '20px 0 0 0',
       padding: 0,
-      fontSize: '35px',
-      color: 'blue'
+      fontSize: '35px'
     },
     h2: {
       margin: '0 0 10px 0',
       padding: 0,
       fontWeight: 400,
-      fontSize: '22px',
-      color: 'green'
+      fontSize: '22px'
     },
     body: {
       borderBottom: '1px solid #eee',

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -1,8 +1,151 @@
-export const baseFonts = {
-  fontFamily: `
+
+/*
+ styles can be overridden by the user in setDefaults:
+
+ setDefaults(
+   inline: true,
+   stylesheet: {
+     header: {h1: {color: 'orange'}},
+     PropVal: {string: {color: 'red'}}
+   }
+ );
+*/
+export const baseStylesheet = {
+  baseFont: {
+    fontFamily: `
     -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto",
     "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif
   `,
-  color: '#444',
-  WebkitFontSmoothing: 'antialiased',
+    color: '#444',
+    WebkitFontSmoothing: 'antialiased',
+  },
+  link: {
+    base: {
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      display: 'block',
+      position: 'fixed',
+      textDecoration: 'none',
+      background: '#28c',
+      color: '#fff',
+      padding: '5px 15px',
+      cursor: 'pointer',
+    },
+    topRight: {
+      top: 0,
+      right: 0,
+      borderRadius: '0 0 0 5px',
+    },
+  },
+  info: {
+    position: 'absolute',
+    background: 'white',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: '0 40px',
+    overflow: 'auto',
+  },
+  children: {
+    position: 'relative',
+    zIndex: 0,
+  },
+  infoBody: {
+    fontWeight: 300,
+    lineHeight: 1.45,
+    fontSize: '15px',
+  },
+  infoContent: {
+    marginBottom: 0,
+  },
+  header: {
+    h1: {
+      margin: '20px 0 0 0',
+      padding: 0,
+      fontSize: '35px',
+      color: 'blue'
+    },
+    h2: {
+      margin: '0 0 10px 0',
+      padding: 0,
+      fontWeight: 400,
+      fontSize: '22px',
+      color: 'green'
+    },
+    body: {
+      borderBottom: '1px solid #eee',
+      marginBottom: 10,
+    },
+  },
+  source: {
+    h1: {
+      margin: '20px 0 0 0',
+      padding: '0 0 5px 0',
+      fontSize: '25px',
+      borderBottom: '1px solid #EEE',
+    },
+  },
+  propTableHead: {
+    margin: '20px 0 0 0',
+  },
+
+  // components
+  Node: {
+    containerStyle: {},
+    tagStyle: {
+      color: '#777',
+    }
+  },
+
+  Props: {
+    propStyle: {  // currently unused
+    },
+    propNameStyle: {
+    },
+    propValueStyle: {
+    }
+  },
+
+  PropVal: {
+    func: {
+      color: '#170',
+    },
+
+    attr: {
+      color: '#666',
+    },
+
+    object: {
+      color: '#666',
+    },
+
+    array: {
+      color: '#666',
+    },
+
+    number: {
+      color: '#a11',
+    },
+
+    string: {
+      color: '#22a',
+      wordBreak: 'break-word',
+    },
+
+    bool: {
+      color: '#a11',
+    },
+
+    empty: {
+      color: '#777',
+    }
+  },
+  PropTable: {
+    table: {
+      marginLeft: -10,
+      borderSpacing: '10px 5px',
+      borderCollapse: 'separate',
+    },
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ export default {
         showHeader: Boolean(options.header),
         showSource: Boolean(options.source),
         propTables: options.propTables,
+        stylesheet: options.stylesheet,
         mtrcConf
       };
 


### PR DESCRIPTION
All styles are now maintained in the context of the Story component,
and passed down to all sub-components (Node, Props, etc). All base
styles for all components are in theme.js, and each property there can
be overridden atomically.

Note: the `dist` files were built with babel, using the existing .babelrc.

Sample usage:

```js
setDefaults({
  inline: true,
  stylesheet: {
    baseFont: {
      fontFamily: 'Avenir-Next'
    },
    header: {
      h1: {color: 'orange'}
    },
    Node: {
      containerStyle: {
        color: '#ff2222',
        fontWeight: '400'
      },
      tagStyle: {
        fontWeight: '400',
        color: '#555'
      }
    },
    PropVal: {
      string: {
        color: 'pink'
      }
    }
  }
});

```