### PR TITLE
Update text on show info button from "?" to "Show info"

### DIFF
--- a/dist/components/Story.js
+++ b/dist/components/Story.js
@@ -227,7 +227,7 @@ var Story = function (_React$Component) {
         _react2.default.createElement(
           'a',
           { style: linkStyle, onClick: openOverlay },
-          '?'
+          'Show Info'
         ),
         _react2.default.createElement(
           'div',

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -140,7 +140,7 @@ export default class Story extends React.Component {
         <div style={stylesheet.children}>
           { this.props.children }
         </div>
-        <a style={linkStyle} onClick={openOverlay}>?</a>
+        <a style={linkStyle} onClick={openOverlay}>Show Info</a>
         <div style={infoStyle}>
           <a style={linkStyle} onClick={closeOverlay}>×</a>
           <div style={stylesheet.infoPage}>


### PR DESCRIPTION
TLDR: Changes '?' to "Show info" so it's more obvious to new users.

As a new user to Storybook, I was very confused when I install this plugin and followed instructions but couldn't see the info. I kept thinking I had installed the plugin incorrectly.

Eventually after I used the inline config, I realised it was working and that actually the way to see the source is to click "?" in the top right.

There doesn't seem to be a reason to be so small/unobstructive, so this just makes it a lot clearer for new users what the button does.