### PR TITLE
Make the info overlay be fixed

### DIFF
--- a/dist/components/Story.js
+++ b/dist/components/Story.js
@@ -86,7 +86,7 @@ var stylesheet = {
     }
   },
   info: {
-    position: 'absolute',
+    position: 'fixed',
     background: 'white',
     top: 0,
     bottom: 0,

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -25,7 +25,7 @@ const stylesheet = {
     },
   },
   info: {
-    position: 'absolute',
+    position: 'fixed',
     background: 'white',
     top: 0,
     bottom: 0,


### PR DESCRIPTION
This fix will make the view of the information be not affected by the decorators positioning, that can be applied to the story. 

Can be the solution for this issues: https://github.com/storybooks/react-storybook-addon-info/issues/137 and https://github.com/storybooks/react-storybook-addon-info/issues/40